### PR TITLE
refactor: localhost verification in 04-channel

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ write a little note why.
 
 - [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
 - [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
-- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
+- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/e46c5ad79d96d84f9896f74470811a927b3544fb/docs/docs/building-modules/10-structure.md).
 - [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
 - [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
 - [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).

--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -96,7 +96,7 @@ We are using [Algolia](https://www.algolia.com) to power full-text search. This 
 ## Consistency
 
 Because the build processes are identical (as is the information contained herein), this file should be kept in sync as
-much as possible with its [counterpart in the Cosmos SDK repo](https://github.com/cosmos/cosmos-sdk/tree/master/docs/DOCS_README.md).
+much as possible with its [counterpart in the Cosmos SDK repo](https://github.com/cosmos/cosmos-sdk/blob/e46c5ad79d96d84f9896f74470811a927b3544fb/docs/README.md).
 
 ### Update and Build the RPC docs
 

--- a/docs/apps/transfer/metrics.md
+++ b/docs/apps/transfer/metrics.md
@@ -4,7 +4,7 @@ order: 6
 
 # Metrics
 
-The IBC transfer application module exposes the following set of [metrics](https://github.com/cosmos/cosmos-sdk/blob/main/docs/core/telemetry.md).
+The IBC transfer application module exposes the following set of [metrics](https://github.com/cosmos/cosmos-sdk/blob/e46c5ad79d96d84f9896f74470811a927b3544fb/docs/docs/core/09-telemetry.md).
 
 | Metric                          | Description                                                                               | Unit            | Type    |
 |:--------------------------------|:------------------------------------------------------------------------------------------|:----------------|:--------|

--- a/docs/ibc/apps.md
+++ b/docs/ibc/apps.md
@@ -468,4 +468,4 @@ callbacks](https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/ibc_
 
 ## Next {hide}
 
-Learn about [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/intro.md) {hide}
+Learn about [building modules](https://github.com/cosmos/cosmos-sdk/blob/e46c5ad79d96d84f9896f74470811a927b3544fb/docs/docs/building-modules/01-intro.md) {hide}

--- a/docs/ibc/apps/apps.md
+++ b/docs/ibc/apps/apps.md
@@ -48,4 +48,4 @@ callbacks](https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/ibc_
 
 ## Next {hide}
 
-Learn about [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/intro.md) {hide}
+Learn about [building modules](https://github.com/cosmos/cosmos-sdk/blob/e46c5ad79d96d84f9896f74470811a927b3544fb/docs/docs/building-modules/01-intro.md) {hide}

--- a/docs/ibc/integration.md
+++ b/docs/ibc/integration.md
@@ -139,7 +139,7 @@ func NewApp(...args) *App {
 
 ### Module Managers
 
-In order to use IBC, we need to add the new modules to the module `Manager` and to the `SimulationManager` in case your application supports [simulations](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/simulator.md).
+In order to use IBC, we need to add the new modules to the module `Manager` and to the `SimulationManager` in case your application supports [simulations](https://github.com/cosmos/cosmos-sdk/blob/e46c5ad79d96d84f9896f74470811a927b3544fb/docs/docs/building-modules/13-simulator.md).
 
 ```go
 // app.go

--- a/docs/ibc/overview.md
+++ b/docs/ibc/overview.md
@@ -136,7 +136,7 @@ Proofs are passed from core IBC to light-clients as bytes. It is up to light cli
 [ICS-24 Host State Machine Requirements](https://github.com/cosmos/ics/tree/master/spec/core/ics-024-host-requirements). 
 - The proof format that all implementations must be able to produce and verify is defined in [ICS-23 Proofs](https://github.com/confio/ics23) implementation.
 
-### [Capabilities](https://github.com/cosmos/cosmos-sdk/blob/master/docs/core/ocap.md)
+### [Capabilities](https://github.com/cosmos/cosmos-sdk/blob/e46c5ad79d96d84f9896f74470811a927b3544fb/docs/docs/core/10-ocap.md)
 
 IBC is intended to work in execution environments where modules do not necessarily trust each
 other. Thus, IBC must authenticate module actions on ports and channels so that only modules with the

--- a/docs/ibc/relayer.md
+++ b/docs/ibc/relayer.md
@@ -7,7 +7,7 @@ order: 6
 ## Pre-requisites Readings
 
 - [IBC Overview](./overview.md) {prereq}
-- [Events](https://github.com/cosmos/cosmos-sdk/blob/master/docs/core/events.md) {prereq}
+- [Events](https://github.com/cosmos/cosmos-sdk/blob/e46c5ad79d96d84f9896f74470811a927b3544fb/docs/docs/core/08-events.md) {prereq}
 
 ## Events
 
@@ -42,5 +42,5 @@ piece of information needed to relay a packet.
 
 ## Example Implementations
 
-- [Golang Relayer](https://github.com/iqlusioninc/relayer)
-- [Hermes](https://github.com/informalsystems/ibc-rs/tree/master/relayer)
+- [Golang Relayer](https://github.com/cosmos/relayer)
+- [Hermes](https://github.com/informalsystems/hermes)

--- a/docs/middleware/ics29-fee/fee-distribution.md
+++ b/docs/middleware/ics29-fee/fee-distribution.md
@@ -95,8 +95,8 @@ type MsgRegisterPayee struct {
 >
 > - `PortId` is invalid (see [24-host naming requirements](https://github.com/cosmos/ibc/blob/master/spec/core/ics-024-host-requirements/README.md#paths-identifiers-separators).
 > - `ChannelId` is invalid (see [24-host naming requirements](https://github.com/cosmos/ibc/blob/master/spec/core/ics-024-host-requirements/README.md#paths-identifiers-separators)).
-> - `Relayer` is an invalid address (see [Cosmos SDK Addresses](https://github.com/cosmos/cosmos-sdk/blob/main/docs/basics/accounts.md#Addresses)).
-> - `Payee` is an invalid address (see [Cosmos SDK Addresses](https://github.com/cosmos/cosmos-sdk/blob/main/docs/basics/accounts.md#Addresses)).
+> - `Relayer` is an invalid address (see [Cosmos SDK Addresses](https://github.com/cosmos/cosmos-sdk/blob/e46c5ad79d96d84f9896f74470811a927b3544fb/docs/docs/basics/03-accounts.md#addresses)).
+> - `Payee` is an invalid address (see [Cosmos SDK Addresses](https://github.com/cosmos/cosmos-sdk/blob/e46c5ad79d96d84f9896f74470811a927b3544fb/docs/docs/basics/03-accounts.md#addresses)).
 
 See below for an example CLI command:
 

--- a/docs/middleware/ics29-fee/fee-distribution.md
+++ b/docs/middleware/ics29-fee/fee-distribution.md
@@ -50,7 +50,7 @@ type MsgRegisterCounterpartyPayee struct {
 >
 > - `PortId` is invalid (see [24-host naming requirements](https://github.com/cosmos/ibc/blob/master/spec/core/ics-024-host-requirements/README.md#paths-identifiers-separators).
 > - `ChannelId` is invalid (see [24-host naming requirements](https://github.com/cosmos/ibc/blob/master/spec/core/ics-024-host-requirements/README.md#paths-identifiers-separators)).
-> - `Relayer` is an invalid address (see [Cosmos SDK Addresses](https://github.com/cosmos/cosmos-sdk/blob/main/docs/basics/accounts.md#Addresses)).
+> - `Relayer` is an invalid address (see [Cosmos SDK Addresses](https://github.com/cosmos/cosmos-sdk/blob/e46c5ad79d96d84f9896f74470811a927b3544fb/docs/docs/basics/03-accounts.md#addresses)).
 > - `CounterpartyPayee` is empty.
 
 See below for an example CLI command:

--- a/docs/migrations/v2-to-v3.md
+++ b/docs/migrations/v2-to-v3.md
@@ -63,7 +63,7 @@ For example, if a chain chooses not to integrate a controller submodule, it may 
 
 #### Add `StoreUpgrades` for ICS27 module
 
-For ICS27 it is also necessary to [manually add store upgrades](https://docs.cosmos.network/v0.44/core/upgrade.html#add-storeupgrades-for-new-modules) for the new ICS27 module and then configure the store loader to apply those upgrades in `app.go`:
+For ICS27 it is also necessary to [manually add store upgrades](https://docs.cosmos.network/main/core/upgrade#add-storeupgrades-for-new-modules) for the new ICS27 module and then configure the store loader to apply those upgrades in `app.go`:
 
 ```go
 if upgradeInfo.Name == "v3" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {

--- a/modules/core/03-connection/types/connection.go
+++ b/modules/core/03-connection/types/connection.go
@@ -10,8 +10,6 @@ import (
 
 var _ exported.ConnectionI = (*ConnectionEnd)(nil)
 
-const LocalhostID = "connection-localhost"
-
 // NewConnectionEnd creates a new ConnectionEnd instance.
 func NewConnectionEnd(state State, clientID string, counterparty Counterparty, versions []*Version, delayPeriod uint64) ConnectionEnd {
 	return ConnectionEnd{

--- a/modules/core/03-connection/types/connection.go
+++ b/modules/core/03-connection/types/connection.go
@@ -10,6 +10,8 @@ import (
 
 var _ exported.ConnectionI = (*ConnectionEnd)(nil)
 
+const LocalhostID = "connection-localhost"
+
 // NewConnectionEnd creates a new ConnectionEnd instance.
 func NewConnectionEnd(state State, clientID string, counterparty Counterparty, versions []*Version, delayPeriod uint64) ConnectionEnd {
 	return ConnectionEnd{

--- a/modules/core/03-connection/types/keys.go
+++ b/modules/core/03-connection/types/keys.go
@@ -28,6 +28,9 @@ const (
 
 	// ConnectionPrefix is the prefix used when creating a connection identifier
 	ConnectionPrefix = "connection-"
+
+	// LocalhostID is the sentinel connection ID used for localhost IBC connections
+	LocalhostID = "connection-localhost"
 )
 
 // FormatConnectionIdentifier returns the connection identifier with the sequence appended.

--- a/modules/core/04-channel/keeper/handshake.go
+++ b/modules/core/04-channel/keeper/handshake.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+
 	connectiontypes "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types"
 	"github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
 	porttypes "github.com/cosmos/ibc-go/v5/modules/core/05-port/types"

--- a/modules/core/04-channel/keeper/handshake.go
+++ b/modules/core/04-channel/keeper/handshake.go
@@ -27,7 +27,7 @@ func (k Keeper) ChanOpenInit(
 	counterparty types.Counterparty,
 	version string,
 ) (string, *capabilitytypes.Capability, error) {
-	if connectionHops[0] != LocalhostID {
+	if connectionHops[0] != connectiontypes.LocalhostID {
 		// connection hop length checked on msg.ValidateBasic()
 		connectionEnd, found := k.connectionKeeper.GetConnection(ctx, connectionHops[0])
 		if !found {
@@ -121,7 +121,7 @@ func (k Keeper) ChanOpenTry(
 
 	// check if the channel state verification should be handled on the localhost
 	// TODO need to check if localhost connections are enabled for this chain
-	if connectionHops[0] == LocalhostID {
+	if connectionHops[0] == connectiontypes.LocalhostID {
 		// get the counterparty channel directly from this chain's channelKeeper store
 		storedChannel, ok := k.GetChannel(ctx, counterparty.PortId, counterparty.ChannelId)
 
@@ -251,7 +251,7 @@ func (k Keeper) ChanOpenAck(
 
 	// check if the channel state verification should be handled on the localhost
 	// TODO need to check if localhost connections are enabled for this chain
-	if channel.ConnectionHops[0] == LocalhostID {
+	if channel.ConnectionHops[0] == connectiontypes.LocalhostID {
 		// get the counterparty channel directly from this chain's channelKeeper store
 		storedChannel, ok := k.GetChannel(ctx, channel.Counterparty.PortId, counterpartyChannelID)
 
@@ -354,7 +354,7 @@ func (k Keeper) ChanOpenConfirm(
 
 	// check if the channel state verification should be handled on the localhost
 	// TODO need to check if localhost connections are enabled for this chain
-	if channel.ConnectionHops[0] == LocalhostID {
+	if channel.ConnectionHops[0] == connectiontypes.LocalhostID {
 		// get the counterparty channel directly from this chain's channelKeeper store
 		storedChannel, ok := k.GetChannel(ctx, channel.Counterparty.PortId, channel.Counterparty.ChannelId)
 
@@ -498,7 +498,7 @@ func (k Keeper) ChanCloseConfirm(
 
 	// check if the channel state verification should be handled on the localhost
 	// TODO need to check if localhost connections are enabled for this chain
-	if channel.ConnectionHops[0] == LocalhostID {
+	if channel.ConnectionHops[0] == connectiontypes.LocalhostID {
 		// get the counterparty channel directly from this chain's channelKeeper store
 		storedChannel, ok := k.GetChannel(ctx, channel.Counterparty.PortId, channel.Counterparty.ChannelId)
 

--- a/modules/core/04-channel/keeper/handshake.go
+++ b/modules/core/04-channel/keeper/handshake.go
@@ -127,10 +127,10 @@ func (k Keeper) ChanOpenTry(
 
 		// check that the counterparty channel actually exists in this chain's channelKeeper store and is in INIT state
 		if !ok {
-			return "", nil, fmt.Errorf("failed localhost channel state verification, counterparty channel does not exist")
+			return "", nil, sdkerrors.Wrap(types.ErrChannelNotFound, "failed localhost channel state verification, counterparty channel does not exist")
 		}
 		if storedChannel.State != types.INIT {
-			return "", nil, fmt.Errorf("failed localhost channel state verification, channel state is not INIT (got %s)", storedChannel.State)
+			return "", nil, sdkerrors.Wrapf(types.ErrInvalidChannelState, "failed localhost channel state verification, channel state is not INIT (got %s)", storedChannel.State)
 		}
 	} else {
 		// GetConnection call takes place in this else block because it will fail on localhost connections
@@ -257,10 +257,10 @@ func (k Keeper) ChanOpenAck(
 
 		// check that the counterparty channel actually exists in this chain's channelKeeper store and is in TRYOPEN state
 		if !ok {
-			return fmt.Errorf("failed localhost channel state verification, counterparty channel does not exist")
+			return sdkerrors.Wrap(types.ErrChannelNotFound, "failed localhost channel state verification, counterparty channel does not exist")
 		}
 		if storedChannel.State != types.TRYOPEN {
-			return fmt.Errorf("failed localhost channel state verification, channel state is not TRYOPEN (got %s)", storedChannel.State)
+			return sdkerrors.Wrapf(types.ErrInvalidChannelState, "failed localhost channel state verification, channel state is not TRYOPEN (got %s)", storedChannel.State)
 		}
 	} else {
 		// GetConnection call takes place in this else block because it will fail on localhost connections
@@ -360,10 +360,10 @@ func (k Keeper) ChanOpenConfirm(
 
 		// check that the counterparty channel actually exists in this chain's channelKeeper store and is in OPEN state
 		if !ok {
-			return fmt.Errorf("failed localhost channel state verification, counterparty channel does not exist")
+			return sdkerrors.Wrap(types.ErrChannelNotFound, "failed localhost channel state verification, counterparty channel does not exist")
 		}
 		if storedChannel.State != types.OPEN {
-			return fmt.Errorf("failed localhost channel state verification, channel state is not OPEN (got %s)", storedChannel.State)
+			return sdkerrors.Wrapf(types.ErrInvalidChannelState, "failed localhost channel state verification, channel state is not OPEN (got %s)", storedChannel.State)
 		}
 	} else {
 		connectionEnd, found := k.connectionKeeper.GetConnection(ctx, channel.ConnectionHops[0])
@@ -504,10 +504,10 @@ func (k Keeper) ChanCloseConfirm(
 
 		// check that the counterparty channel actually exists in this chain's channelKeeper store and is in CLOSED state
 		if !ok {
-			return fmt.Errorf("failed localhost channel state verification, counterparty channel does not exist")
+			return sdkerrors.Wrap(types.ErrChannelNotFound, "failed localhost channel state verification, counterparty channel does not exist")
 		}
 		if storedChannel.State != types.CLOSED {
-			return fmt.Errorf("failed localhost channel state verification, channel state is not CLOSED (got %s)", storedChannel.State)
+			return sdkerrors.Wrapf(types.ErrInvalidChannelState, "failed localhost channel state verification, channel state is not CLOSED (got %s)", storedChannel.State)
 		}
 	} else {
 		// GetConnection call takes place in this else block because it will fail on localhost connections

--- a/modules/core/04-channel/keeper/handshake_test.go
+++ b/modules/core/04-channel/keeper/handshake_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+
 	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	connectiontypes "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types"
 	"github.com/cosmos/ibc-go/v5/modules/core/04-channel/keeper"

--- a/modules/core/04-channel/keeper/handshake_test.go
+++ b/modules/core/04-channel/keeper/handshake_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+
 	porttypes "github.com/cosmos/ibc-go/v5/modules/core/05-port/types"
 
 	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"

--- a/modules/core/04-channel/keeper/handshake_test.go
+++ b/modules/core/04-channel/keeper/handshake_test.go
@@ -877,6 +877,22 @@ func (suite *KeeperTestSuite) TestLocalhostChanOpenTry() {
 			suite.chainB.CreatePortCapability(suite.chainB.GetSimApp().ScopedIBCMockKeeper, ibctesting.MockPort)
 			portCap = suite.chainB.GetPortCapability(ibctesting.MockPort)
 		}, true},
+		{"channel ids are not equal", func() {
+			suite.coordinator.SetupLocalhostConnections(path)
+			path.SetChannelUnordered()
+
+			err := path.EndpointA.ChanOpenInit()
+			suite.Require().NoError(err)
+
+			err = path.EndpointB.LocalhostChanOpenTry()
+			suite.Require().NoError(err)
+
+			// ensure that both channel ends end up with different ids after ChanOpenTry
+			suite.Require().NotEqual(path.EndpointA.ChannelID, path.EndpointB.ChannelID)
+
+			suite.chainB.CreatePortCapability(suite.chainB.GetSimApp().ScopedIBCMockKeeper, ibctesting.MockPort)
+			portCap = suite.chainB.GetPortCapability(ibctesting.MockPort)
+		}, true},
 		{"localhost channel verification failed", func() {
 			expError = types.ErrChannelNotFound
 			// the channel for EndpointA does not exist in state

--- a/modules/core/04-channel/keeper/keeper_test.go
+++ b/modules/core/04-channel/keeper/keeper_test.go
@@ -36,6 +36,13 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.coordinator.CommitNBlocks(suite.chainB, 2)
 }
 
+// SetupLocalhostTest creates a coordinator where the source and counterparty chains are the same chain.
+func (suite *KeeperTestSuite) SetupLocalhostTest() {
+	suite.coordinator = ibctesting.NewCoordinator(suite.T(), 2)
+	suite.chainA = suite.coordinator.GetChain(ibctesting.GetChainID(1))
+	suite.chainB = suite.coordinator.GetChain(ibctesting.GetChainID(1))
+}
+
 // TestSetChannel create clients and connections on both chains. It tests for the non-existence
 // and existence of a channel in INIT on chainA.
 func (suite *KeeperTestSuite) TestSetChannel() {

--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -483,14 +483,16 @@ func (k Keeper) AcknowledgePacket(
 		}
 
 		// get the desired state directly from this chain's channelKeeper
-		storedAck, ok := k.GetPacketAcknowledgement(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+		storedAck, ok := k.GetPacketAcknowledgement(ctx, packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())
 
 		// check that the packet acknowledgement actually exists in this chain's channelKeeper store
 		if !ok {
 			return fmt.Errorf("couldn't verify localhost acknowledgement, acknowledgement does not exist")
 		}
-		if !bytes.Equal(acknowledgement, storedAck) {
-			return fmt.Errorf("couldn't verify localhost acknowledgement (%s ≠ %s)", storedAck, acknowledgement)
+
+		expectedAck := types.CommitAcknowledgement(acknowledgement)
+		if !bytes.Equal(expectedAck, storedAck) {
+			return fmt.Errorf("couldn't verify localhost acknowledgement (%s ≠ %s)", expectedAck, storedAck)
 		}
 	} else {
 		// GetConnection call takes place in this else block because it will fail on localhost connections

--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"bytes"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -229,10 +228,10 @@ func (k Keeper) RecvPacket(
 
 		// check that the packet commitment actually exists in this chain's channelKeeper store
 		if len(storedCommitment) == 0 {
-			return fmt.Errorf("couldn't verify localhost packet commitment, commitment does not exist")
+			return sdkerrors.Wrap(types.ErrPacketCommitmentNotFound, "couldn't verify localhost packet commitment, commitment does not exist")
 		}
 		if !bytes.Equal(storedCommitment, commitment) {
-			return fmt.Errorf("couldn't verify localhost packet commitment (%s ≠ %s)", storedCommitment, commitment)
+			return sdkerrors.Wrapf(types.ErrInvalidPacket, "couldn't verify localhost packet commitment (%s ≠ %s)", storedCommitment, commitment)
 		}
 
 	} else {
@@ -487,12 +486,12 @@ func (k Keeper) AcknowledgePacket(
 
 		// check that the packet acknowledgement actually exists in this chain's channelKeeper store
 		if !ok {
-			return fmt.Errorf("couldn't verify localhost acknowledgement, acknowledgement does not exist")
+			return sdkerrors.Wrap(types.ErrInvalidAcknowledgement, "couldn't verify localhost acknowledgement, acknowledgement does not exist")
 		}
 
 		expectedAck := types.CommitAcknowledgement(acknowledgement)
 		if !bytes.Equal(expectedAck, storedAck) {
-			return fmt.Errorf("couldn't verify localhost acknowledgement (%s ≠ %s)", expectedAck, storedAck)
+			return sdkerrors.Wrapf(types.ErrInvalidAcknowledgement, "couldn't verify localhost acknowledgement (%s ≠ %s)", expectedAck, storedAck)
 		}
 	} else {
 		// GetConnection call takes place in this else block because it will fail on localhost connections

--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -18,7 +18,7 @@ import (
 )
 
 // TODO possibly move this constant to somewhere that makes more sense
-const localhostID = "localhost"
+const LocalhostID = "connection-localhost"
 
 // SendPacket is called by a module in order to send an IBC packet on a channel
 // end owned by the calling module to the corresponding module on the counterparty
@@ -202,7 +202,7 @@ func (k Keeper) RecvPacket(
 
 	// check if the packet commitment verification should be handled on the localhost
 	// TODO need to check if localhost connections are enabled for this chain
-	if channel.ConnectionHops[0] == localhostID {
+	if channel.ConnectionHops[0] == LocalhostID {
 		// get the desired state directly from this chain's channelKeeper
 		storedCommitment := k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
@@ -444,7 +444,7 @@ func (k Keeper) AcknowledgePacket(
 
 	// check if the packet acknowledgement verification should be handled on the localhost
 	// TODO need to check if localhost connections are enabled for this chain
-	if channel.ConnectionHops[0] == localhostID {
+	if channel.ConnectionHops[0] == LocalhostID {
 		commitment = k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 		if len(commitment) == 0 {

--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -58,7 +58,7 @@ func (k Keeper) SendPacket(
 	}
 
 	// perform packet send verification
-	err := k.verifyPacketSend(ctx, channel.ConnectionHops[0], packet)
+	err := k.validatePacketSend(ctx, channel.ConnectionHops[0], packet)
 	if err != nil {
 		return err
 	}

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -741,7 +741,19 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 				path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID,
 				types.NewChannel(types.OPEN, types.ORDERED, types.NewCounterparty(path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID), []string{"connection-1000"}, path.EndpointA.ChannelConfig.Version),
 			)
+
+			// create packet commitment
 			packet = types.NewPacket(ibctesting.MockPacketData, 1, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, disabledTimeoutTimestamp)
+			commitment := types.CommitPacket(suite.chainA.GetSimApp().AppCodec(), packet)
+
+			suite.chainA.App.GetIBCKeeper().ChannelKeeper.SetPacketCommitment(
+				suite.chainA.GetContext(),
+				path.EndpointA.ChannelConfig.PortID,
+				path.EndpointA.ChannelID,
+				packet.Sequence,
+				commitment,
+			)
+
 			suite.chainA.CreateChannelCapability(suite.chainA.GetSimApp().ScopedIBCMockKeeper, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 			channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 		}, false},
@@ -758,7 +770,19 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 				path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID,
 				types.NewChannel(types.OPEN, types.ORDERED, types.NewCounterparty(path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID), []string{path.EndpointA.ConnectionID}, path.EndpointA.ChannelConfig.Version),
 			)
+
+			// create packet commitment
 			packet = types.NewPacket(ibctesting.MockPacketData, 1, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, timeoutHeight, disabledTimeoutTimestamp)
+			commitment := types.CommitPacket(suite.chainA.GetSimApp().AppCodec(), packet)
+
+			suite.chainA.App.GetIBCKeeper().ChannelKeeper.SetPacketCommitment(
+				suite.chainA.GetContext(),
+				path.EndpointA.ChannelConfig.PortID,
+				path.EndpointA.ChannelID,
+				packet.Sequence,
+				commitment,
+			)
+
 			suite.chainA.CreateChannelCapability(suite.chainA.GetSimApp().ScopedIBCMockKeeper, path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 			channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 		}, false},

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -491,7 +491,7 @@ func (suite *KeeperTestSuite) TestRecvPacket() {
 				} else {
 					suite.Require().Equal(uint64(1), nextSeqRecv, "sequence incremented for UNORDERED channel")
 					suite.Require().True(receiptStored, "packet receipt not stored after RecvPacket in UNORDERED channel")
-					suite.Require().Equal(string([]byte{byte(1)}), receipt, "packet receipt is not empty string")
+					suite.Require().Equal(string([]byte{byte(1)}), receipt, "packet receipt in store does not match expected packet receipt value")
 				}
 			} else {
 				suite.Require().Error(err)

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -59,7 +59,7 @@ func (k Keeper) TimeoutPacket(
 
 		// check that timeout height or timeout timestamp has passed on the other end
 		timeoutHeight := packet.GetTimeoutHeight()
-		if (timeoutHeight.IsZero() || proofHeight.LT(timeoutHeight)) &&
+		if timeoutHeight.IsZero() || uint64(ctx.BlockHeight()) < timeoutHeight.GetRevisionHeight() &&
 			(packet.GetTimeoutTimestamp() == 0 || uint64(ctx.BlockTime().UnixNano()) < packet.GetTimeoutTimestamp()) {
 			return sdkerrors.Wrap(types.ErrPacketTimeout, "packet timeout has not been reached for height or timestamp")
 		}
@@ -119,8 +119,6 @@ func (k Keeper) TimeoutPacket(
 		return nil
 	}
 
-	// GetConnection call takes place in this else block because it will fail on localhost connections
-	// due to the connection not actually existing in state.
 	connectionEnd, found := k.connectionKeeper.GetConnection(ctx, channel.ConnectionHops[0])
 	if !found {
 		return sdkerrors.Wrap(

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -59,7 +59,7 @@ func (k Keeper) TimeoutPacket(
 
 		// check that timeout height or timeout timestamp has passed on the other end
 		timeoutHeight := packet.GetTimeoutHeight()
-		if timeoutHeight.IsZero() || uint64(ctx.BlockHeight()) < timeoutHeight.GetRevisionHeight() &&
+		if (timeoutHeight.IsZero() || uint64(ctx.BlockHeight()) < timeoutHeight.GetRevisionHeight()) &&
 			(packet.GetTimeoutTimestamp() == 0 || uint64(ctx.BlockTime().UnixNano()) < packet.GetTimeoutTimestamp()) {
 			return sdkerrors.Wrap(types.ErrPacketTimeout, "packet timeout has not been reached for height or timestamp")
 		}

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -55,7 +55,7 @@ func (k Keeper) TimeoutPacket(
 
 	// check if the packet timeout verification should be handled on the localhost
 	// TODO need to check if localhost connections are enabled for this chain
-	if channel.ConnectionHops[0] == localhostID {
+	if channel.ConnectionHops[0] == LocalhostID {
 
 		// check that timeout height or timeout timestamp has passed on the other end
 		timeoutHeight := packet.GetTimeoutHeight()
@@ -287,7 +287,7 @@ func (k Keeper) TimeoutOnClose(
 
 	// check if the packet timeout verification should be handled on the localhost
 	// TODO need to check if localhost connections are enabled for this chain
-	if channel.ConnectionHops[0] == localhostID {
+	if channel.ConnectionHops[0] == LocalhostID {
 		commitment := k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 		if len(commitment) == 0 {

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -55,7 +55,7 @@ func (k Keeper) TimeoutPacket(
 
 	// check if the packet timeout verification should be handled on the localhost
 	// TODO need to check if localhost connections are enabled for this chain
-	if channel.ConnectionHops[0] == LocalhostID {
+	if channel.ConnectionHops[0] == connectiontypes.LocalhostID {
 
 		// check that timeout height or timeout timestamp has passed on the other end
 		timeoutHeight := packet.GetTimeoutHeight()
@@ -287,7 +287,7 @@ func (k Keeper) TimeoutOnClose(
 
 	// check if the packet timeout verification should be handled on the localhost
 	// TODO need to check if localhost connections are enabled for this chain
-	if channel.ConnectionHops[0] == LocalhostID {
+	if channel.ConnectionHops[0] == connectiontypes.LocalhostID {
 		commitment := k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
 
 		if len(commitment) == 0 {

--- a/modules/core/04-channel/keeper/timeout.go
+++ b/modules/core/04-channel/keeper/timeout.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"bytes"
-	"fmt"
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -101,16 +100,16 @@ func (k Keeper) TimeoutPacket(
 
 			expectedNextSeq, ok := k.GetNextSequenceRecv(ctx, packet.GetDestPort(), packet.GetDestChannel())
 			if !ok {
-				return fmt.Errorf("failed localhost next sequence receive verification, next sequence receive does not exist in store")
+				return sdkerrors.Wrap(types.ErrSequenceReceiveNotFound, "failed localhost next sequence receive verification, next sequence receive does not exist in store")
 			}
 			// check that the recv sequence is as claimed
 			if nextSequenceRecv != expectedNextSeq {
-				return fmt.Errorf("failed localhost next sequence receive verification, (%d ≠ %d)", expectedNextSeq, nextSequenceRecv)
+				return sdkerrors.Wrapf(types.ErrPacketSequenceOutOfOrder, "failed localhost next sequence receive verification, (%d ≠ %d)", expectedNextSeq, nextSequenceRecv)
 			}
 		case types.UNORDERED:
 			_, ok := k.GetPacketReceipt(ctx, packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())
 			if ok {
-				return fmt.Errorf("failed localhost packet receipt absence verification")
+				return sdkerrors.Wrap(types.ErrAcknowledgementExists, "failed localhost packet receipt absence verification")
 			}
 		default:
 			panic(sdkerrors.Wrapf(types.ErrInvalidChannelOrdering, channel.Ordering.String()))
@@ -310,7 +309,7 @@ func (k Keeper) TimeoutOnClose(
 		}
 
 		if counterpartyChan.State != types.CLOSED {
-			return fmt.Errorf("failed localhost timeout verification, counterparty channel state is not CLOSED (got %s)", counterpartyChan.State)
+			return sdkerrors.Wrapf(types.ErrInvalidChannelState, "failed localhost timeout verification, counterparty channel state is not CLOSED (got %s)", counterpartyChan.State)
 		}
 
 		switch channel.Ordering {
@@ -325,16 +324,16 @@ func (k Keeper) TimeoutOnClose(
 
 			expectedNextSeq, ok := k.GetNextSequenceRecv(ctx, packet.GetDestPort(), packet.GetDestChannel())
 			if !ok {
-				return fmt.Errorf("failed localhost next sequence receive verification, next sequence receive does not exist in store")
+				return sdkerrors.Wrap(types.ErrSequenceReceiveNotFound, "failed localhost next sequence receive verification, next sequence receive does not exist in store")
 			}
 			// check that the recv sequence is as claimed
 			if nextSequenceRecv != expectedNextSeq {
-				return fmt.Errorf("failed localhost next sequence receive verification, (%d ≠ %d)", expectedNextSeq, nextSequenceRecv)
+				return sdkerrors.Wrapf(types.ErrPacketSequenceOutOfOrder, "failed localhost next sequence receive verification, (%d ≠ %d)", expectedNextSeq, nextSequenceRecv)
 			}
 		case types.UNORDERED:
 			_, ok := k.GetPacketReceipt(ctx, packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())
 			if ok {
-				return fmt.Errorf("failed localhost packet receipt absence verification")
+				return sdkerrors.Wrapf(types.ErrAcknowledgementExists, "failed localhost packet receipt absence verification")
 			}
 		default:
 			panic(sdkerrors.Wrapf(types.ErrInvalidChannelOrdering, channel.Ordering.String()))

--- a/modules/core/04-channel/keeper/verify.go
+++ b/modules/core/04-channel/keeper/verify.go
@@ -1,0 +1,547 @@
+package keeper
+
+import (
+	"bytes"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
+	connectiontypes "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types"
+	"github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
+	"github.com/cosmos/ibc-go/v5/modules/core/exported"
+)
+
+// channelStateOpts defines the data necessary to perform channel state verification.
+type channelStateOpts struct {
+	order               types.Order
+	expectedState       types.State
+	counterpartyVersion string
+	portID              string
+	channelID           string
+	counterpartyPortID  string
+	counterpartyChanID  string
+	proofHeight         exported.Height
+	proof               []byte
+}
+
+// verifyChannelState performs the appropriate channel state verification logic for either a localhost connection
+// or a counterparty chain.
+func (k Keeper) verifyChannelState(
+	ctx sdk.Context,
+	connectionID string,
+	opts channelStateOpts,
+) error {
+	if connectionID == connectiontypes.LocalhostID {
+		// get the counterparty channel directly from this chain's channelKeeper store
+		storedChannel, ok := k.GetChannel(ctx, opts.counterpartyPortID, opts.counterpartyChanID)
+
+		// check that the counterparty channel actually exists in this chain's channelKeeper store and is in the expected state
+		if !ok {
+			return sdkerrors.Wrap(types.ErrChannelNotFound, "failed localhost channel state verification, counterparty channel does not exist")
+		}
+
+		if storedChannel.State != opts.expectedState {
+			return sdkerrors.Wrapf(types.ErrInvalidChannelState, "failed localhost channel state verification, channel state is not %s (got %s)", opts.expectedState, storedChannel.State)
+		}
+	} else {
+		connectionEnd, found := k.connectionKeeper.GetConnection(ctx, connectionID)
+		if !found {
+			return sdkerrors.Wrap(connectiontypes.ErrConnectionNotFound, connectionID)
+		}
+
+		if connectionEnd.GetState() != int32(connectiontypes.OPEN) {
+			return sdkerrors.Wrapf(
+				connectiontypes.ErrInvalidConnectionState,
+				"connection state is not OPEN (got %s)", connectiontypes.State(connectionEnd.GetState()).String(),
+			)
+		}
+
+		// connection version & feature verification only need to happen on ChanOpenTry
+		if opts.expectedState == types.INIT {
+			getVersions := connectionEnd.GetVersions()
+			if len(getVersions) != 1 {
+				return sdkerrors.Wrapf(
+					connectiontypes.ErrInvalidVersion,
+					"single version must be negotiated on connection before opening channel, got: %v",
+					getVersions,
+				)
+			}
+
+			if !connectiontypes.VerifySupportedFeature(getVersions[0], opts.order.String()) {
+				return sdkerrors.Wrapf(
+					connectiontypes.ErrInvalidVersion,
+					"connection version %s does not support channel ordering: %s", getVersions[0], opts.order.String(),
+				)
+			}
+		}
+
+		counterpartyHops := []string{connectionEnd.GetCounterparty().GetConnectionID()}
+
+		// expectedCounterparty is the counterparty of the counterparty's channel end (i.e self)
+		expectedCounterparty := types.NewCounterparty(opts.portID, opts.channelID)
+		expectedChannel := types.NewChannel(
+			opts.expectedState, opts.order, expectedCounterparty,
+			counterpartyHops, opts.counterpartyVersion,
+		)
+
+		if err := k.connectionKeeper.VerifyChannelState(
+			ctx, connectionEnd, opts.proofHeight, opts.proof,
+			opts.counterpartyPortID, opts.counterpartyChanID, expectedChannel,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// verifyPacketSend performs the appropriate packet verification logic for either a packet being sent on a localhost
+// connection or a packet being sent to a counterparty chain.
+func (k Keeper) verifyPacketSend(ctx sdk.Context, connectionID string, packet exported.PacketI) error {
+	if connectionID == connectiontypes.LocalhostID {
+		// check if packet is timed out
+		latestHeight := uint64(ctx.BlockHeight())
+		timeoutHeight := packet.GetTimeoutHeight()
+		if !timeoutHeight.IsZero() && latestHeight >= timeoutHeight.GetRevisionHeight() {
+			return sdkerrors.Wrapf(
+				types.ErrPacketTimeout,
+				"receiving chain block height >= packet timeout height (%d >= %s)", latestHeight, timeoutHeight,
+			)
+		}
+
+		latestTimestamp := uint64(ctx.BlockTime().UnixNano())
+		if packet.GetTimeoutTimestamp() != 0 && latestTimestamp >= packet.GetTimeoutTimestamp() {
+			return sdkerrors.Wrapf(
+				types.ErrPacketTimeout,
+				"receiving chain block timestamp >= packet timeout timestamp (%s >= %s)", time.Unix(0, int64(latestTimestamp)), time.Unix(0, int64(packet.GetTimeoutTimestamp())),
+			)
+		}
+	} else {
+		connectionEnd, found := k.connectionKeeper.GetConnection(ctx, connectionID)
+		if !found {
+			return sdkerrors.Wrap(connectiontypes.ErrConnectionNotFound, connectionID)
+		}
+
+		clientState, found := k.clientKeeper.GetClientState(ctx, connectionEnd.GetClientID())
+		if !found {
+			return clienttypes.ErrConsensusStateNotFound
+		}
+
+		// prevent accidental sends with clients that cannot be updated
+		clientStore := k.clientKeeper.ClientStore(ctx, connectionEnd.GetClientID())
+		if status := clientState.Status(ctx, clientStore, k.cdc); status != exported.Active {
+			return sdkerrors.Wrapf(clienttypes.ErrClientNotActive, "cannot send packet using client (%s) with status %s", connectionEnd.GetClientID(), status)
+		}
+
+		// check if packet is timed out on the receiving chain
+		latestHeight := clientState.GetLatestHeight()
+		timeoutHeight := packet.GetTimeoutHeight()
+		if !timeoutHeight.IsZero() && latestHeight.GTE(timeoutHeight) {
+			return sdkerrors.Wrapf(
+				types.ErrPacketTimeout,
+				"receiving chain block height >= packet timeout height (%s >= %s)", latestHeight, timeoutHeight,
+			)
+		}
+
+		latestTimestamp, err := k.connectionKeeper.GetTimestampAtHeight(ctx, connectionEnd, latestHeight)
+		if err != nil {
+			return err
+		}
+
+		if packet.GetTimeoutTimestamp() != 0 && latestTimestamp >= packet.GetTimeoutTimestamp() {
+			return sdkerrors.Wrapf(
+				types.ErrPacketTimeout,
+				"receiving chain block timestamp >= packet timeout timestamp (%s >= %s)", time.Unix(0, int64(latestTimestamp)), time.Unix(0, int64(packet.GetTimeoutTimestamp())),
+			)
+		}
+	}
+
+	return nil
+}
+
+// verifyPacketCommitment performs the appropriate packet verification logic for either a packet commitment on a localhost
+// connection or a packet commitment on a counterparty chain.
+func (k Keeper) verifyPacketCommitment(
+	ctx sdk.Context,
+	connectionID string,
+	packet exported.PacketI,
+	expectedState []byte,
+	proof []byte,
+	proofHeight exported.Height,
+) error {
+	if connectionID == connectiontypes.LocalhostID {
+		// get the desired packet commitment hash directly from this chain's channelKeeper
+		actualState := k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+
+		// check that the packet commitment actually exists in this chain's channelKeeper store and matches the expected state
+		if len(actualState) == 0 {
+			return sdkerrors.Wrap(types.ErrPacketCommitmentNotFound, "couldn't verify localhost packet commitment, commitment does not exist")
+		}
+
+		if !bytes.Equal(actualState, expectedState) {
+			return sdkerrors.Wrapf(types.ErrInvalidPacket, "couldn't verify localhost packet commitment (%s ≠ %s)", actualState, expectedState)
+		}
+
+	} else {
+		// Connection must be OPEN to receive a packet. It is possible for connection to not yet be open if packet was
+		// sent optimistically before connection and channel handshake completed. However, to receive a packet,
+		// connection and channel must both be open
+		connectionEnd, found := k.connectionKeeper.GetConnection(ctx, connectionID)
+		if !found {
+			return sdkerrors.Wrap(connectiontypes.ErrConnectionNotFound, connectionID)
+		}
+
+		if connectionEnd.GetState() != int32(connectiontypes.OPEN) {
+			return sdkerrors.Wrapf(
+				connectiontypes.ErrInvalidConnectionState,
+				"connection state is not OPEN (got %s)", connectiontypes.State(connectionEnd.GetState()).String(),
+			)
+		}
+
+		// verify that the counterparty did commit to sending this packet
+		if err := k.connectionKeeper.VerifyPacketCommitment(
+			ctx, connectionEnd, proofHeight, proof,
+			packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence(),
+			expectedState,
+		); err != nil {
+			return sdkerrors.Wrap(err, "couldn't verify counterparty packet commitment")
+		}
+	}
+
+	return nil
+}
+
+// verifyPacketAcknowledgement performs the appropriate verification logic for either an acknowledgement on a localhost
+// connection or an acknowledgement on a counterparty chain.
+func (k Keeper) verifyPacketAcknowledgement(
+	ctx sdk.Context,
+	connectionID string,
+	packet exported.PacketI,
+	expectedState []byte,
+	proof []byte,
+	proofHeight exported.Height,
+) error {
+	if connectionID == connectiontypes.LocalhostID {
+		// get the desired ack hash directly from this chain's channelKeeper
+		storedAck, ok := k.GetPacketAcknowledgement(ctx, packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())
+
+		// check that the packet acknowledgement actually exists in this chain's channelKeeper store and matches the expected state
+		if !ok {
+			return sdkerrors.Wrap(types.ErrInvalidAcknowledgement, "couldn't verify localhost acknowledgement, acknowledgement does not exist")
+		}
+
+		expectedAck := types.CommitAcknowledgement(expectedState)
+		if !bytes.Equal(expectedAck, storedAck) {
+			return sdkerrors.Wrapf(types.ErrInvalidAcknowledgement, "couldn't verify localhost acknowledgement (%s ≠ %s)", expectedAck, storedAck)
+		}
+	} else {
+		connectionEnd, found := k.connectionKeeper.GetConnection(ctx, connectionID)
+		if !found {
+			return sdkerrors.Wrap(connectiontypes.ErrConnectionNotFound, connectionID)
+		}
+
+		if connectionEnd.GetState() != int32(connectiontypes.OPEN) {
+			return sdkerrors.Wrapf(
+				connectiontypes.ErrInvalidConnectionState,
+				"connection state is not OPEN (got %s)", connectiontypes.State(connectionEnd.GetState()).String(),
+			)
+		}
+
+		if err := k.connectionKeeper.VerifyPacketAcknowledgement(
+			ctx, connectionEnd, proofHeight, proof, packet.GetDestPort(), packet.GetDestChannel(),
+			packet.GetSequence(), expectedState,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// verifyTimeoutPacket performs the appropriate verification logic for either a timeout on a localhost connection or
+// a timeout on a counterparty chain.
+func (k Keeper) verifyTimeoutPacket(
+	ctx sdk.Context,
+	packet exported.PacketI,
+	channel types.Channel,
+	expectedNextSeqRecv uint64,
+	proofHeight exported.Height,
+	proof []byte,
+) error {
+	if channel.ConnectionHops[0] == connectiontypes.LocalhostID {
+		// check that timeout height or timeout timestamp has passed on the other end
+		timeoutHeight := packet.GetTimeoutHeight()
+		if (timeoutHeight.IsZero() || uint64(ctx.BlockHeight()) < timeoutHeight.GetRevisionHeight()) &&
+			(packet.GetTimeoutTimestamp() == 0 || uint64(ctx.BlockTime().UnixNano()) < packet.GetTimeoutTimestamp()) {
+			return sdkerrors.Wrap(types.ErrPacketTimeout, "packet timeout has not been reached for height or timestamp")
+		}
+
+		commitment := k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+
+		if len(commitment) == 0 {
+			EmitTimeoutPacketEvent(ctx, packet, channel)
+			// This error indicates that the timeout has already been relayed
+			// or there is a misconfigured relayer attempting to prove a timeout
+			// for a packet never sent. Core IBC will treat this error as a no-op in order to
+			// prevent an entire relay transaction from failing and consuming unnecessary fees.
+			return types.ErrNoOpMsg
+		}
+
+		if channel.State != types.OPEN {
+			return sdkerrors.Wrapf(
+				types.ErrInvalidChannelState,
+				"channel state is not OPEN (got %s)", channel.State.String(),
+			)
+		}
+
+		packetCommitment := types.CommitPacket(k.cdc, packet)
+
+		// verify we sent the packet and haven't cleared it out yet
+		if !bytes.Equal(commitment, packetCommitment) {
+			return sdkerrors.Wrapf(types.ErrInvalidPacket, "packet commitment bytes are not equal: got (%v), expected (%v)", commitment, packetCommitment)
+		}
+
+		switch channel.Ordering {
+		case types.ORDERED:
+			// check that packet has not been received
+			if expectedNextSeqRecv > packet.GetSequence() {
+				return sdkerrors.Wrapf(
+					types.ErrPacketReceived,
+					"packet already received, next sequence receive > packet sequence (%d > %d)", expectedNextSeqRecv, packet.GetSequence(),
+				)
+			}
+
+			actualNextSeqRecv, ok := k.GetNextSequenceRecv(ctx, packet.GetDestPort(), packet.GetDestChannel())
+			if !ok {
+				return sdkerrors.Wrap(types.ErrSequenceReceiveNotFound, "failed localhost next sequence receive verification, next sequence receive does not exist in store")
+			}
+
+			// check that the recv sequence is as claimed
+			if actualNextSeqRecv != expectedNextSeqRecv {
+				return sdkerrors.Wrapf(types.ErrPacketSequenceOutOfOrder, "failed localhost next sequence receive verification, (%d ≠ %d)", actualNextSeqRecv, expectedNextSeqRecv)
+			}
+		case types.UNORDERED:
+			_, ok := k.GetPacketReceipt(ctx, packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())
+			if ok {
+				return sdkerrors.Wrap(types.ErrAcknowledgementExists, "failed localhost packet receipt absence verification")
+			}
+		default:
+			panic(sdkerrors.Wrapf(types.ErrInvalidChannelOrdering, channel.Ordering.String()))
+		}
+
+		return nil
+	}
+
+	connectionEnd, found := k.connectionKeeper.GetConnection(ctx, channel.ConnectionHops[0])
+	if !found {
+		return sdkerrors.Wrap(
+			connectiontypes.ErrConnectionNotFound,
+			channel.ConnectionHops[0],
+		)
+	}
+
+	// check that timeout height or timeout timestamp has passed on the other end
+	proofTimestamp, err := k.connectionKeeper.GetTimestampAtHeight(ctx, connectionEnd, proofHeight)
+	if err != nil {
+		return err
+	}
+
+	timeoutHeight := packet.GetTimeoutHeight()
+	if (timeoutHeight.IsZero() || proofHeight.LT(timeoutHeight)) &&
+		(packet.GetTimeoutTimestamp() == 0 || proofTimestamp < packet.GetTimeoutTimestamp()) {
+		return sdkerrors.Wrap(types.ErrPacketTimeout, "packet timeout has not been reached for height or timestamp")
+	}
+
+	commitment := k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+
+	if len(commitment) == 0 {
+		EmitTimeoutPacketEvent(ctx, packet, channel)
+		// This error indicates that the timeout has already been relayed
+		// or there is a misconfigured relayer attempting to prove a timeout
+		// for a packet never sent. Core IBC will treat this error as a no-op in order to
+		// prevent an entire relay transaction from failing and consuming unnecessary fees.
+		return types.ErrNoOpMsg
+	}
+
+	if channel.State != types.OPEN {
+		return sdkerrors.Wrapf(
+			types.ErrInvalidChannelState,
+			"channel state is not OPEN (got %s)", channel.State.String(),
+		)
+	}
+
+	packetCommitment := types.CommitPacket(k.cdc, packet)
+
+	// verify we sent the packet and haven't cleared it out yet
+	if !bytes.Equal(commitment, packetCommitment) {
+		return sdkerrors.Wrapf(types.ErrInvalidPacket, "packet commitment bytes are not equal: got (%v), expected (%v)", commitment, packetCommitment)
+	}
+
+	switch channel.Ordering {
+	case types.ORDERED:
+		// check that packet has not been received
+		if expectedNextSeqRecv > packet.GetSequence() {
+			return sdkerrors.Wrapf(
+				types.ErrPacketReceived,
+				"packet already received, next sequence receive > packet sequence (%d > %d)", expectedNextSeqRecv, packet.GetSequence(),
+			)
+		}
+
+		// check that the recv sequence is as claimed
+		err = k.connectionKeeper.VerifyNextSequenceRecv(
+			ctx, connectionEnd, proofHeight, proof,
+			packet.GetDestPort(), packet.GetDestChannel(), expectedNextSeqRecv,
+		)
+	case types.UNORDERED:
+		err = k.connectionKeeper.VerifyPacketReceiptAbsence(
+			ctx, connectionEnd, proofHeight, proof,
+			packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence(),
+		)
+	default:
+		panic(sdkerrors.Wrapf(types.ErrInvalidChannelOrdering, channel.Ordering.String()))
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// verifyTimeoutOnClose performs the appropriate verification logic for either a timeout on a localhost channel closing or
+// a timeout on a counterparty chain's channel closing.
+func (k Keeper) verifyTimeoutOnClose(
+	ctx sdk.Context,
+	packet exported.PacketI,
+	channel types.Channel,
+	actualNextSeqRecv uint64,
+	proofHeight exported.Height,
+	proof []byte,
+	proofClosed []byte,
+) error {
+	if channel.ConnectionHops[0] == connectiontypes.LocalhostID {
+		commitment := k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+
+		if len(commitment) == 0 {
+			EmitTimeoutPacketEvent(ctx, packet, channel)
+			// This error indicates that the timeout has already been relayed
+			// or there is a misconfigured relayer attempting to prove a timeout
+			// for a packet never sent. Core IBC will treat this error as a no-op in order to
+			// prevent an entire relay transaction from failing and consuming unnecessary fees.
+			return types.ErrNoOpMsg
+		}
+
+		packetCommitment := types.CommitPacket(k.cdc, packet)
+
+		// verify we sent the packet and haven't cleared it out yet
+		if !bytes.Equal(commitment, packetCommitment) {
+			return sdkerrors.Wrapf(types.ErrInvalidPacket, "packet commitment bytes are not equal: got (%v), expected (%v)", commitment, packetCommitment)
+		}
+
+		counterpartyChan, found := k.GetChannel(ctx, packet.GetDestPort(), packet.GetDestChannel())
+		if !found {
+			return sdkerrors.Wrapf(types.ErrChannelNotFound, "port ID (%s) channel ID (%s)", packet.GetDestPort(), packet.GetDestChannel())
+		}
+
+		if counterpartyChan.State != types.CLOSED {
+			return sdkerrors.Wrapf(types.ErrInvalidChannelState, "failed localhost timeout verification, counterparty channel state is not CLOSED (got %s)", counterpartyChan.State)
+		}
+
+		switch channel.Ordering {
+		case types.ORDERED:
+			// check that packet has not been received
+			if actualNextSeqRecv > packet.GetSequence() {
+				return sdkerrors.Wrapf(
+					types.ErrPacketReceived,
+					"packet already received, next sequence receive > packet sequence (%d > %d)", actualNextSeqRecv, packet.GetSequence(),
+				)
+			}
+
+			actualNextSeq, ok := k.GetNextSequenceRecv(ctx, packet.GetDestPort(), packet.GetDestChannel())
+			if !ok {
+				return sdkerrors.Wrap(types.ErrSequenceReceiveNotFound, "failed localhost next sequence receive verification, next sequence receive does not exist in store")
+			}
+			// check that the recv sequence is as claimed
+			if actualNextSeqRecv != actualNextSeq {
+				return sdkerrors.Wrapf(types.ErrPacketSequenceOutOfOrder, "failed localhost next sequence receive verification, (%d ≠ %d)", actualNextSeq, actualNextSeqRecv)
+			}
+		case types.UNORDERED:
+			_, ok := k.GetPacketReceipt(ctx, packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())
+			if ok {
+				return sdkerrors.Wrapf(types.ErrAcknowledgementExists, "failed localhost packet receipt absence verification")
+			}
+		default:
+			panic(sdkerrors.Wrapf(types.ErrInvalidChannelOrdering, channel.Ordering.String()))
+		}
+
+		return nil
+	}
+
+	connectionEnd, found := k.connectionKeeper.GetConnection(ctx, channel.ConnectionHops[0])
+	if !found {
+		return sdkerrors.Wrap(connectiontypes.ErrConnectionNotFound, channel.ConnectionHops[0])
+	}
+
+	commitment := k.GetPacketCommitment(ctx, packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence())
+
+	if len(commitment) == 0 {
+		EmitTimeoutPacketEvent(ctx, packet, channel)
+		// This error indicates that the timeout has already been relayed
+		// or there is a misconfigured relayer attempting to prove a timeout
+		// for a packet never sent. Core IBC will treat this error as a no-op in order to
+		// prevent an entire relay transaction from failing and consuming unnecessary fees.
+		return types.ErrNoOpMsg
+	}
+
+	packetCommitment := types.CommitPacket(k.cdc, packet)
+
+	// verify we sent the packet and haven't cleared it out yet
+	if !bytes.Equal(commitment, packetCommitment) {
+		return sdkerrors.Wrapf(types.ErrInvalidPacket, "packet commitment bytes are not equal: got (%v), expected (%v)", commitment, packetCommitment)
+	}
+
+	counterpartyHops := []string{connectionEnd.GetCounterparty().GetConnectionID()}
+
+	counterparty := types.NewCounterparty(packet.GetSourcePort(), packet.GetSourceChannel())
+	expectedChannel := types.NewChannel(
+		types.CLOSED, channel.Ordering, counterparty, counterpartyHops, channel.Version,
+	)
+
+	// check that the opposing channel end has closed
+	if err := k.connectionKeeper.VerifyChannelState(
+		ctx, connectionEnd, proofHeight, proofClosed,
+		channel.Counterparty.PortId, channel.Counterparty.ChannelId,
+		expectedChannel,
+	); err != nil {
+		return err
+	}
+
+	var err error
+	switch channel.Ordering {
+	case types.ORDERED:
+		// check that packet has not been received
+		if actualNextSeqRecv > packet.GetSequence() {
+			return sdkerrors.Wrapf(types.ErrInvalidPacket, "packet already received, next sequence receive > packet sequence (%d > %d", actualNextSeqRecv, packet.GetSequence())
+		}
+
+		// check that the recv sequence is as claimed
+		err = k.connectionKeeper.VerifyNextSequenceRecv(
+			ctx, connectionEnd, proofHeight, proof,
+			packet.GetDestPort(), packet.GetDestChannel(), actualNextSeqRecv,
+		)
+	case types.UNORDERED:
+		err = k.connectionKeeper.VerifyPacketReceiptAbsence(
+			ctx, connectionEnd, proofHeight, proof,
+			packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence(),
+		)
+	default:
+		panic(sdkerrors.Wrapf(types.ErrInvalidChannelOrdering, channel.Ordering.String()))
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/modules/core/04-channel/types/msgs.go
+++ b/modules/core/04-channel/types/msgs.go
@@ -7,7 +7,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
-	commitmenttypes "github.com/cosmos/ibc-go/v5/modules/core/23-commitment/types"
 	host "github.com/cosmos/ibc-go/v5/modules/core/24-host"
 )
 
@@ -92,12 +91,6 @@ func (msg MsgChannelOpenTry) ValidateBasic() error {
 	if msg.PreviousChannelId != "" {
 		return sdkerrors.Wrap(ErrInvalidChannelIdentifier, "previous channel identifier must be empty, this field has been deprecated as crossing hellos are no longer supported")
 	}
-	if len(msg.ProofInit) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof init")
-	}
-	if msg.ProofHeight.IsZero() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidHeight, "proof height must be non-zero")
-	}
 	if msg.Channel.State != TRYOPEN {
 		return sdkerrors.Wrapf(ErrInvalidChannelState,
 			"channel state must be TRYOPEN in MsgChannelOpenTry. expected: %s, got: %s",
@@ -156,12 +149,6 @@ func (msg MsgChannelOpenAck) ValidateBasic() error {
 	if err := host.ChannelIdentifierValidator(msg.CounterpartyChannelId); err != nil {
 		return sdkerrors.Wrap(err, "invalid counterparty channel ID")
 	}
-	if len(msg.ProofTry) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof try")
-	}
-	if msg.ProofHeight.IsZero() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidHeight, "proof height must be non-zero")
-	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
@@ -203,12 +190,6 @@ func (msg MsgChannelOpenConfirm) ValidateBasic() error {
 	}
 	if !IsValidChannelID(msg.ChannelId) {
 		return ErrInvalidChannelIdentifier
-	}
-	if len(msg.ProofAck) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof ack")
-	}
-	if msg.ProofHeight.IsZero() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidHeight, "proof height must be non-zero")
 	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
@@ -291,12 +272,6 @@ func (msg MsgChannelCloseConfirm) ValidateBasic() error {
 	if !IsValidChannelID(msg.ChannelId) {
 		return ErrInvalidChannelIdentifier
 	}
-	if len(msg.ProofInit) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof init")
-	}
-	if msg.ProofHeight.IsZero() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidHeight, "proof height must be non-zero")
-	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
@@ -332,12 +307,6 @@ func NewMsgRecvPacket(
 
 // ValidateBasic implements sdk.Msg
 func (msg MsgRecvPacket) ValidateBasic() error {
-	if len(msg.ProofCommitment) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof")
-	}
-	if msg.ProofHeight.IsZero() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidHeight, "proof height must be non-zero")
-	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
@@ -381,12 +350,6 @@ func NewMsgTimeout(
 
 // ValidateBasic implements sdk.Msg
 func (msg MsgTimeout) ValidateBasic() error {
-	if len(msg.ProofUnreceived) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty unreceived proof")
-	}
-	if msg.ProofHeight.IsZero() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidHeight, "proof height must be non-zero")
-	}
 	if msg.NextSequenceRecv == 0 {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidSequence, "next sequence receive cannot be 0")
 	}
@@ -429,15 +392,6 @@ func (msg MsgTimeoutOnClose) ValidateBasic() error {
 	if msg.NextSequenceRecv == 0 {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidSequence, "next sequence receive cannot be 0")
 	}
-	if len(msg.ProofUnreceived) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof")
-	}
-	if len(msg.ProofClose) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof of closed counterparty channel end")
-	}
-	if msg.ProofHeight.IsZero() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidHeight, "proof height must be non-zero")
-	}
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
@@ -476,12 +430,6 @@ func NewMsgAcknowledgement(
 
 // ValidateBasic implements sdk.Msg
 func (msg MsgAcknowledgement) ValidateBasic() error {
-	if len(msg.ProofAcked) == 0 {
-		return sdkerrors.Wrap(commitmenttypes.ErrInvalidProof, "cannot submit an empty proof")
-	}
-	if msg.ProofHeight.IsZero() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidHeight, "proof height must be non-zero")
-	}
 	if len(msg.Acknowledgement) == 0 {
 		return sdkerrors.Wrap(ErrInvalidAcknowledgement, "ack bytes cannot be empty")
 	}

--- a/modules/core/04-channel/types/msgs_test.go
+++ b/modules/core/04-channel/types/msgs_test.go
@@ -10,7 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
-	log "github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
 
 	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
@@ -158,7 +158,6 @@ func (suite *TypesTestSuite) TestMsgChannelOpenTryValidateBasic() {
 		{"too long port id", types.NewMsgChannelOpenTry(invalidLongPort, version, types.ORDERED, connHops, cpportid, cpchanid, version, suite.proof, height, addr), false},
 		{"port id contains non-alpha", types.NewMsgChannelOpenTry(invalidPort, version, types.ORDERED, connHops, cpportid, cpchanid, version, suite.proof, height, addr), false},
 		{"", types.NewMsgChannelOpenTry(portid, version, types.ORDERED, connHops, cpportid, cpchanid, "", suite.proof, height, addr), true},
-		{"proof height is zero", types.NewMsgChannelOpenTry(portid, version, types.ORDERED, connHops, cpportid, cpchanid, version, suite.proof, clienttypes.ZeroHeight(), addr), false},
 		{"invalid channel order", types.NewMsgChannelOpenTry(portid, version, types.Order(4), connHops, cpportid, cpchanid, version, suite.proof, height, addr), false},
 		{"connection hops more than 1 ", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, invalidConnHops, cpportid, cpchanid, version, suite.proof, height, addr), false},
 		{"too short connection id", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, invalidShortConnHops, cpportid, cpchanid, version, suite.proof, height, addr), false},
@@ -167,7 +166,6 @@ func (suite *TypesTestSuite) TestMsgChannelOpenTryValidateBasic() {
 		{"", types.NewMsgChannelOpenTry(portid, "", types.UNORDERED, connHops, cpportid, cpchanid, version, suite.proof, height, addr), true},
 		{"invalid counterparty port id", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, connHops, invalidPort, cpchanid, version, suite.proof, height, addr), false},
 		{"invalid counterparty channel id", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, connHops, cpportid, invalidChannel, version, suite.proof, height, addr), false},
-		{"empty proof", types.NewMsgChannelOpenTry(portid, version, types.UNORDERED, connHops, cpportid, cpchanid, version, emptyProof, height, addr), false},
 		{"channel not in TRYOPEN state", &types.MsgChannelOpenTry{portid, "", initChannel, version, suite.proof, height, addr}, false},
 		{"previous channel id is not empty", &types.MsgChannelOpenTry{portid, chanid, initChannel, version, suite.proof, height, addr}, false},
 	}
@@ -201,8 +199,6 @@ func (suite *TypesTestSuite) TestMsgChannelOpenAckValidateBasic() {
 		{"too long channel id", types.NewMsgChannelOpenAck(portid, invalidLongChannel, chanid, version, suite.proof, height, addr), false},
 		{"channel id contains non-alpha", types.NewMsgChannelOpenAck(portid, invalidChannel, chanid, version, suite.proof, height, addr), false},
 		{"", types.NewMsgChannelOpenAck(portid, chanid, chanid, "", suite.proof, height, addr), true},
-		{"empty proof", types.NewMsgChannelOpenAck(portid, chanid, chanid, version, emptyProof, height, addr), false},
-		{"proof height is zero", types.NewMsgChannelOpenAck(portid, chanid, chanid, version, suite.proof, clienttypes.ZeroHeight(), addr), false},
 		{"invalid counterparty channel id", types.NewMsgChannelOpenAck(portid, chanid, invalidShortChannel, version, suite.proof, height, addr), false},
 	}
 
@@ -234,8 +230,6 @@ func (suite *TypesTestSuite) TestMsgChannelOpenConfirmValidateBasic() {
 		{"too short channel id", types.NewMsgChannelOpenConfirm(portid, invalidShortChannel, suite.proof, height, addr), false},
 		{"too long channel id", types.NewMsgChannelOpenConfirm(portid, invalidLongChannel, suite.proof, height, addr), false},
 		{"channel id contains non-alpha", types.NewMsgChannelOpenConfirm(portid, invalidChannel, suite.proof, height, addr), false},
-		{"empty proof", types.NewMsgChannelOpenConfirm(portid, chanid, emptyProof, height, addr), false},
-		{"proof height is zero", types.NewMsgChannelOpenConfirm(portid, chanid, suite.proof, clienttypes.ZeroHeight(), addr), false},
 	}
 
 	for _, tc := range testCases {
@@ -296,8 +290,6 @@ func (suite *TypesTestSuite) TestMsgChannelCloseConfirmValidateBasic() {
 		{"too short channel id", types.NewMsgChannelCloseConfirm(portid, invalidShortChannel, suite.proof, height, addr), false},
 		{"too long channel id", types.NewMsgChannelCloseConfirm(portid, invalidLongChannel, suite.proof, height, addr), false},
 		{"channel id contains non-alpha", types.NewMsgChannelCloseConfirm(portid, invalidChannel, suite.proof, height, addr), false},
-		{"empty proof", types.NewMsgChannelCloseConfirm(portid, chanid, emptyProof, height, addr), false},
-		{"proof height is zero", types.NewMsgChannelCloseConfirm(portid, chanid, suite.proof, clienttypes.ZeroHeight(), addr), false},
 	}
 
 	for _, tc := range testCases {
@@ -322,8 +314,6 @@ func (suite *TypesTestSuite) TestMsgRecvPacketValidateBasic() {
 		expPass bool
 	}{
 		{"success", types.NewMsgRecvPacket(packet, suite.proof, height, addr), true},
-		{"proof height is zero", types.NewMsgRecvPacket(packet, suite.proof, clienttypes.ZeroHeight(), addr), false},
-		{"proof contain empty proof", types.NewMsgRecvPacket(packet, emptyProof, height, addr), false},
 		{"missing signer address", types.NewMsgRecvPacket(packet, suite.proof, height, emptyAddr), false},
 		{"invalid packet", types.NewMsgRecvPacket(invalidPacket, suite.proof, height, addr), false},
 	}
@@ -358,10 +348,8 @@ func (suite *TypesTestSuite) TestMsgTimeoutValidateBasic() {
 		expPass bool
 	}{
 		{"success", types.NewMsgTimeout(packet, 1, suite.proof, height, addr), true},
-		{"proof height must be > 0", types.NewMsgTimeout(packet, 1, suite.proof, clienttypes.ZeroHeight(), addr), false},
 		{"seq 0", types.NewMsgTimeout(packet, 0, suite.proof, height, addr), false},
 		{"missing signer address", types.NewMsgTimeout(packet, 1, suite.proof, height, emptyAddr), false},
-		{"cannot submit an empty proof", types.NewMsgTimeout(packet, 1, emptyProof, height, addr), false},
 		{"invalid packet", types.NewMsgTimeout(invalidPacket, 1, suite.proof, height, addr), false},
 	}
 
@@ -388,9 +376,6 @@ func (suite *TypesTestSuite) TestMsgTimeoutOnCloseValidateBasic() {
 	}{
 		{"success", types.NewMsgTimeoutOnClose(packet, 1, suite.proof, suite.proof, height, addr), true},
 		{"seq 0", types.NewMsgTimeoutOnClose(packet, 0, suite.proof, suite.proof, height, addr), false},
-		{"empty proof", types.NewMsgTimeoutOnClose(packet, 1, emptyProof, suite.proof, height, addr), false},
-		{"empty proof close", types.NewMsgTimeoutOnClose(packet, 1, suite.proof, emptyProof, height, addr), false},
-		{"proof height is zero", types.NewMsgTimeoutOnClose(packet, 1, suite.proof, suite.proof, clienttypes.ZeroHeight(), addr), false},
 		{"signer address is empty", types.NewMsgTimeoutOnClose(packet, 1, suite.proof, suite.proof, height, emptyAddr), false},
 		{"invalid packet", types.NewMsgTimeoutOnClose(invalidPacket, 1, suite.proof, suite.proof, height, addr), false},
 	}
@@ -417,10 +402,8 @@ func (suite *TypesTestSuite) TestMsgAcknowledgementValidateBasic() {
 		expPass bool
 	}{
 		{"success", types.NewMsgAcknowledgement(packet, packet.GetData(), suite.proof, height, addr), true},
-		{"proof height must be > 0", types.NewMsgAcknowledgement(packet, packet.GetData(), suite.proof, clienttypes.ZeroHeight(), addr), false},
 		{"empty ack", types.NewMsgAcknowledgement(packet, nil, suite.proof, height, addr), false},
 		{"missing signer address", types.NewMsgAcknowledgement(packet, packet.GetData(), suite.proof, height, emptyAddr), false},
-		{"cannot submit an empty proof", types.NewMsgAcknowledgement(packet, packet.GetData(), emptyProof, height, addr), false},
 		{"invalid packet", types.NewMsgAcknowledgement(invalidPacket, packet.GetData(), suite.proof, height, addr), false},
 	}
 

--- a/modules/core/23-commitment/types/merkle.go
+++ b/modules/core/23-commitment/types/merkle.go
@@ -272,8 +272,10 @@ func verifyChainedMembershipProof(root []byte, specs []*ics23.ProofSpec, proofs 
 
 // blankMerkleProof and blankProofOps will be used to compare against their zero values,
 // and are declared as globals to avoid having to unnecessarily re-allocate on every comparison.
-var blankMerkleProof = &MerkleProof{}
-var blankProofOps = &tmcrypto.ProofOps{}
+var (
+	blankMerkleProof = &MerkleProof{}
+	blankProofOps    = &tmcrypto.ProofOps{}
+)
 
 // Empty returns true if the root is empty
 func (proof *MerkleProof) Empty() bool {

--- a/testing/coordinator.go
+++ b/testing/coordinator.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cosmos/ibc-go/v5/modules/core/04-channel/keeper"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/cosmos/ibc-go/v5/modules/core/04-channel/keeper"
 )
 
 var (

--- a/testing/coordinator.go
+++ b/testing/coordinator.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/ibc-go/v5/modules/core/04-channel/keeper"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
@@ -99,6 +100,13 @@ func (coord *Coordinator) SetupConnections(path *Path) {
 	coord.SetupClients(path)
 
 	coord.CreateConnections(path)
+}
+
+// SetupLocalhostConnections is a helper function to set the connection ID to the localhost connection
+// identifier on both the source and counterparty ends.
+func (coord *Coordinator) SetupLocalhostConnections(path *Path) {
+	path.EndpointA.ConnectionID = keeper.LocalhostID
+	path.EndpointB.ConnectionID = keeper.LocalhostID
 }
 
 // CreateConnection constructs and executes connection handshake messages in order to create

--- a/testing/coordinator.go
+++ b/testing/coordinator.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	"github.com/cosmos/ibc-go/v5/modules/core/03-connection/types"
+	connectiontypes "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types"
 )
 
 var (
@@ -114,8 +114,8 @@ func (coord *Coordinator) SetupConnections(path *Path) {
 // SetupLocalhostConnections is a helper function to set the connection ID to the localhost connection
 // identifier on both the source and counterparty ends.
 func (coord *Coordinator) SetupLocalhostConnections(path *Path) {
-	path.EndpointA.ConnectionID = types.LocalhostID
-	path.EndpointB.ConnectionID = types.LocalhostID
+	path.EndpointA.ConnectionID = connectiontypes.LocalhostID
+	path.EndpointB.ConnectionID = connectiontypes.LocalhostID
 }
 
 // CreateConnection constructs and executes connection handshake messages in order to create

--- a/testing/endpoint.go
+++ b/testing/endpoint.go
@@ -578,6 +578,12 @@ func (endpoint *Endpoint) AcknowledgePacket(packet channeltypes.Packet, ack []by
 	return endpoint.Chain.sendMsgs(ackMsg)
 }
 
+// AcknowledgeLocalhostPacket sends a MsgAcknowledgement to the channel associated with the endpoint.
+func (endpoint *Endpoint) AcknowledgeLocalhostPacket(packet channeltypes.Packet, ack []byte) error {
+	ackMsg := channeltypes.NewMsgAcknowledgement(packet, ack, nil, clienttypes.Height{}, endpoint.Chain.SenderAccount.GetAddress().String())
+	return endpoint.Chain.sendMsgs(ackMsg)
+}
+
 // TimeoutPacket sends a MsgTimeout to the channel associated with the endpoint.
 func (endpoint *Endpoint) TimeoutPacket(packet channeltypes.Packet) error {
 	// get proof for timeout based on channel order

--- a/testing/path.go
+++ b/testing/path.go
@@ -35,6 +35,12 @@ func (path *Path) SetChannelOrdered() {
 	path.EndpointB.ChannelConfig.Order = channeltypes.ORDERED
 }
 
+// SetChannelUnordered sets the channel order for both endpoints to UNORDERED.
+func (path *Path) SetChannelUnordered() {
+	path.EndpointA.ChannelConfig.Order = channeltypes.UNORDERED
+	path.EndpointB.ChannelConfig.Order = channeltypes.UNORDERED
+}
+
 // RelayPacket attempts to relay the packet first on EndpointA and then on EndpointB
 // if EndpointA does not contain a packet commitment for that packet. An error is returned
 // if a relay step fails or the packet commitment does not exist on either endpoint.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR adds verification logic for localhost ibc packet, channel state, and timeout verification in 04-channel. Since both the source and counterparty ends are located on the same chain we can skip composing and verifying proofs by querying the relevant state from the store and performing some checks on the expected vs. actual data.

Changes are found in
- SendPacket
- RecvPacket
- AcknowledgePacket
- TimeoutPacket
- TimeoutOnClose
- ChanOpenInit
- ChanOpenTry
- ChanOpenAck
- ChanOpenConfirm
- ChanCloseInit
- ChanCloseConfirm

ref: #2535

Note: CHANGELOG will need an entry added for this before upstreaming. There may also be relevant docs that need adjusted.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes